### PR TITLE
1.21.2 support

### DIFF
--- a/1_21_recipe/data/dlljs_smithing/recipe/netherite_upgrade_smithing_template.json
+++ b/1_21_recipe/data/dlljs_smithing/recipe/netherite_upgrade_smithing_template.json
@@ -7,9 +7,15 @@
     "###"
   ],
   "key": {
-    "#": "minecraft:netherrack",
-    "C": "minecraft:diamond",
-    "S": "minecraft:netherite_scrap"
+    "#": {
+      "item": "minecraft:netherrack"
+    },
+    "C": {
+      "item": "minecraft:diamond"
+    },
+    "S": {
+      "item": "minecraft:netherite_scrap"
+    }
   },
   "result": {
     "id": "minecraft:netherite_upgrade_smithing_template",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Additionally, it adds a crafting recipe for the [Netherite Upgrade Smithing Temp
 This data pack does not affect the odds of finding smithing templates in generated structures. The existing duplication recipes for smithing templates are also not affected.
 
 #### Supported Minecraft: Java Edition versions:
-* For 1.21, use v1.0.1 or later.
+* For 1.21.2 snapshots, use v1.0.2-pre1 or later.
+* For 1.21 - 1.21.1, use v1.0.1 or later.
 * For 1.20.3 - 1.20.6, use v1.0.0.
 
 # How to Install

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Reusable Smithing Templates
 A Minecraft: Java Edition data pack that makes smithing templates reusable and netherite upgrades easily craftable.
 
-**Avaliable on:** **GitHub** | [Modrinth](https://modrinth.com/datapack/reusable-smithing-templates) | [CurseForge](https://www.curseforge.com/minecraft/data-packs/reusable-smithing-templates) |   [Planet Minecraft](https://www.planetminecraft.com/data-pack/reusable-smithing-templates/)
+**Available on:** **GitHub** | [Modrinth](https://modrinth.com/datapack/reusable-smithing-templates) | [CurseForge](https://www.curseforge.com/minecraft/data-packs/reusable-smithing-templates) |   [Planet Minecraft](https://www.planetminecraft.com/data-pack/reusable-smithing-templates/)
 
 [Smithing templates](https://minecraft.wiki/w/Smithing_Template) are items that can be found at structures and are used to alter weapons, tools and armor on a [smithing table](https://minecraft.wiki/w/Smithing_Table). Personally, I didn't like how smithing templates would be consumed when used. It limits creativity with armor trims and makes obtaining netherite items more difficult than it needs to be. This data pack fixes this issue by returning the smithing template back to the player when it's used on a smithing table. 
 
@@ -10,7 +10,7 @@ A Minecraft: Java Edition data pack that makes smithing templates reusable and n
 
 Additionally, it adds a crafting recipe for the [Netherite Upgrade Smithing Template](https://minecraft.wiki/w/Netherite_Upgrade) that's much less resource intensive and doesn't require you to hunt it down in a generated structure.
 
-![Recipe for the Netherite Upgrade Smiothing Template that the data pack adds. 8 netherrack in a U-shape, 1 diamond in the middle and 1 netherite scrap at the top.](img/netherite_upgrade_recipe.png)
+![Recipe for the Netherite Upgrade Smithing Template that the data pack adds. 8 netherrack in a U-shape, 1 diamond in the middle and 1 netherite scrap at the top.](img/netherite_upgrade_recipe.png)
 
 This data pack does not affect the odds of finding smithing templates in generated structures. The existing duplication recipes for smithing templates are also not affected.
 

--- a/data/minecraft/function/load.mcfunction
+++ b/data/minecraft/function/load.mcfunction
@@ -1,1 +1,1 @@
-say Reusable Smithing Templates data pack v1.0.1 has been loaded
+say Reusable Smithing Templates data pack v1.0.2 has been loaded

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,18 @@
 {
   "pack": {
-    "pack_format": 48,
-    "supported_formats": 48,
+    "pack_format": 49,
+    "supported_formats": [
+      48,
+      49
+    ],
     "description": "Makes smithing templates reusable. By Dlljs."
+  },
+  "overlays": {
+    "entries": [
+      {
+        "formats": 48,
+        "directory": "1_21_recipe"
+      }
+    ]
   }
 }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,10 +1,10 @@
 {
   "pack": {
-    "pack_format": 49,
-    "supported_formats": [
-      48,
-      49
-    ],
+    "pack_format": 50,
+    "supported_formats": {
+      "min_inclusive": 48,
+      "max_inclusive": 50
+    },
     "description": "Makes smithing templates reusable. By Dlljs."
   },
   "overlays": {


### PR DESCRIPTION
The only change needed is to change the way ingredients are listed in the recipe file `netherite_upgrade_smithing_template.json`. Pack version `49` makes the listing simpler.

However, the old file (from pack version `48`, 1.21 - 1.21.1) is kept to maintain compatibility if possible. I may have to remove it if it completely breaks everything! 😝

**Will not be merged until Minecraft: Java Edition 1.21.2 is officially released.**